### PR TITLE
Update base image to get recent smartmontools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 ARG BUILD_DATE="N/A"
 ARG REVISION="N/A"


### PR DESCRIPTION
This updates `smartmontools` from 6.6 (2017-11-05) to 7.2 (2020-12-30) which, among other things, makes `smartmon.sh` report basic info about NVMe devices