### PR TITLE
build: Use Ubuntu Plucky for base Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM ubuntu:plucky
 
 ARG BUILD_DATE="N/A"
 ARG REVISION="N/A"
@@ -17,23 +17,23 @@ LABEL org.opencontainers.image.authors="Alexander Trost <galexrt@googlemail.com>
 RUN apt-get -q update && \
     apt-get -q upgrade -y && \
     apt-get install -y --no-install-recommends \
-        ca-certificates \
-        git \
-        jq \
-        moreutils \
-        moreutils \
-        nvme-cli \
-        pciutils \
-        smartmontools \
-        wget \
-        python3 \
-        python3-prometheus-client \
-        gpg \
-        gpg-agent && \
+    ca-certificates \
+    git \
+    jq \
+    moreutils \
+    moreutils \
+    nvme-cli \
+    pciutils \
+    smartmontools \
+    wget \
+    python3 \
+    python3-prometheus-client \
+    gpg \
+    gpg-agent && \
     mkdir -p /scripts && \
     git clone --depth 1 --branch master --single-branch \
-        https://github.com/prometheus-community/node-exporter-textfile-collector-scripts.git \
-        /scripts && \
+    https://github.com/prometheus-community/node-exporter-textfile-collector-scripts.git \
+    /scripts && \
     chmod 755 /scripts/* && \
     /usr/sbin/update-smart-drivedb && \
     apt-get remove -y gpg git gpg-agent && \


### PR DESCRIPTION
Since https://github.com/prometheus-community/node-exporter-textfile-collector-scripts/commit/a2b43e19be1e64c31b626ca827506977cac93488, `nvme-cli` v2.11+ must be used for the `nvme_metrics.py` script to properly work. Given that the current Docker base image, Debian Bookworm, only offers v2.4, this script no longer functions. The three possible ways to remediate this problem would be:
- Pin the `node-exporter-textfile-collector-scripts` to a specific commit version predating this breaking change
- Alter the Docker container of this repository to build a `nvme-cli` version
- Change the base image to a distribution that already exposes a more recent version of the `nvme-cli`  package

I have already attempted having the Dockerfile compile a later `nvme-cli` version, however newer releases also rely on a much newer version of `libnvme` compared to what Debian repositories offer.